### PR TITLE
Installer: Added a retry loop to do_mount

### DIFF
--- a/common/stages/Functions/library
+++ b/common/stages/Functions/library
@@ -201,8 +201,15 @@ do_mount()
     validate_mount_point "${MNT}" || return 1
 
     do_cmd mkdir -p "${MNT}"
-    do_cmd mount "$@" || return 1
-    return 0
+
+    # Retry for a minute, sleeping 3 seconds between tries to
+    # allow slow devices such as USB CD/DVD to come online
+    for TRY in {1..20}; do
+      do_cmd mount "$@" && return 0
+      sleep 3
+    done
+
+    return 1
 }
 
 # Unmounts a filesystem. Pass the mount point, not the device.


### PR DESCRIPTION
In order to provide some failsafe for slow devices (USB CD/DVD are
common culprit) not being up and available by the time the installer
attempts to mount them, added a retry loop (1 minute, albeit arbitrary)
to hopefully give ample time for all devices to come up when being
mounted. Reproductions most likely to occur with automated install
answerfiles using CD/DVD.

OXT-16 #comment Added a retry loop to do_mount in the installer library
