### PR TITLE
OXT-389: use a bigger RSA certificate to match the bigger key

### DIFF
--- a/part2/stages/Set-password
+++ b/part2/stages/Set-password
@@ -131,13 +131,14 @@ else
         exit ${Abort}
     fi
 
+    dialog --infobox "Generating RSA keys, please wait..." 3 40
     if [ "${PLAIN_TEXT_PASSWORD}" ] ; then
 
         # Generate recovery public/private key using plain text password
         # as a passphrase.
         echo -n "${PLAIN_TEXT_PASSWORD}" | \
             openssl genrsa -des3 -out "${RECOVERY_PRIVATE_KEY_CONF}" \
-                           -passout stdin 2048 || \
+                           -passout stdin 8192 || \
             exit ${Abort}
 
         echo -n "${PLAIN_TEXT_PASSWORD}" | \
@@ -148,7 +149,7 @@ else
     elif [ "${DEFER_PASSWORD}" = "true" ] ; then
 
         # Generate recovery public/private key without a passphrase.
-        openssl genrsa -out "${RECOVERY_PRIVATE_KEY_CONF}" 2048 || \
+        openssl genrsa -out "${RECOVERY_PRIVATE_KEY_CONF}" 8192 || \
             exit ${Abort}
 
         openssl rsa -pubout -out "${RECOVERY_PUBLIC_KEY_CONF}" \


### PR DESCRIPTION
Signed-off-by: Jed <lejosnej@ainfosec.com>