### PR TITLE
moved /lib/udev/path_id to /usr/bin/udevadm as former no longer exists

### DIFF
--- a/part1/stages/Detect-repo
+++ b/part1/stages/Detect-repo
@@ -47,7 +47,7 @@ fi
 
 for BLOCK in /sys/block/${DEFAULT_USB_DEVICE}* ; do
     DEV=$(basename "${BLOCK}")
-    if /lib/udev/path_id "/block/${DEV}" | egrep -q ".*-usb-.*" ; then
+    if /usr/bin/udevadm test-builtin path_id "/block/${DEV}" | egrep -q ".*-usb-.*" ; then
         for i in /dev/${DEV}* ; do
             do_mount -o ro ${i} ${TEMP_USB_MOUNT} >&2 || continue
 


### PR DESCRIPTION
path_id no longer works from within installer, however udevadm does work to find usb devices to install from