### PR TITLE
part2: pass dom0 mount point to recovery unlock

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -507,7 +507,7 @@ mount_config()
             echo "mount_config: ERROR luksOpen-ing /dev/xenclient/config" >&2
         fi
     else # not already mounted, mapped and platform state is sealed
-        recovery_unlock "/dev/xenclient/config" config >&2
+        recovery_unlock "/dev/xenclient/config" config "${DOM0_MOUNT}" >&2
         if [ $? -eq 0 ]; then
             echo "mount_config: config mapped successfully, mounting" >&2
             do_mount /dev/mapper/config ${DOM0_MOUNT}/config || return 1


### PR DESCRIPTION
This passes the DOM0 mount point into recovery unlock for when
upgrading from a xc scheme to the new ML scheme.

OST-955

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>