### PR TITLE
lvm: only activate xenclient vgroup.

### DIFF
--- a/part2/stages/Find-existing-install
+++ b/part2/stages/Find-existing-install
@@ -149,7 +149,7 @@ a fresh install?" 17 55
 }
 
 do_cmd vgscan --mknodes >&2
-do_cmd vgchange -a y >&2
+do_cmd vgchange -a y xenclient >&2
 
 detect_prior_installation
 

--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -35,7 +35,7 @@ mk_xc_lvm()
     do_cmd lvresize -f /dev/xenclient/storage -L-1G || return 1
 
     do_cmd vgscan --mknodes || return 1
-    do_cmd vgchange -a y || return 1
+    do_cmd vgchange -a y xenclient || return 1
 }
 
 apply_xc_packages()


### PR DESCRIPTION
Otherwise it might require modules that are not shipped with the
installer and fail to install for that reason.

OXT-971