### PR TITLE
OXT-1052: Warn user and always remove all partitions.

### DIFF
--- a/part2/stages/Configure-partitions
+++ b/part2/stages/Configure-partitions
@@ -82,7 +82,7 @@ partition_exists()
 {
     local PARTITION="$1"
 
-    [ -b "/dev/${PARTITION}" ]
+    [ -b "/dev/$(get_partition_node ${PARTITION})" ]
 }
 
 is_xc_partition()

--- a/part2/stages/Make-XC-partition
+++ b/part2/stages/Make-XC-partition
@@ -47,9 +47,9 @@ remove_existing_partitions()
         mixedgauge "Removing disk partitions..." 5
 
         for P in ${REMOVE_PARTITIONS} ; do
-            local DISK=$(get_partition_disk "${PARTITION}")
-            local PARTITION_NUM=$(get_partition_number "${PARTITION}")
-            local NODE=$(get_partition_node "${PARTITION}")
+            local DISK=$(get_partition_disk "${P}")
+            local PARTITION_NUM=$(get_partition_number "${P}")
+            local NODE=$(get_partition_node "${P}")
             local DISK_DEV="/dev/${DISK}"
             local PARTITION_DEV="/dev/${NODE}"
 

--- a/part2/stages/Remove-partitions
+++ b/part2/stages/Remove-partitions
@@ -1,6 +1,6 @@
 #!/bin/ash
 #
-# Copyright (c) 2011 Citrix Systems, Inc.
+# Copyright (c) 2017 Assured Information Security, Inc.
 # 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/part2/stages/Remove-partitions
+++ b/part2/stages/Remove-partitions
@@ -1,0 +1,29 @@
+#!/bin/ash
+#
+# Copyright (c) 2011 Citrix Systems, Inc.
+# 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+. ${SCRIPT_DIR}/functions
+
+. ${DISK_CONF}
+# ^^^ defines ${TARGET_DISK}
+
+do_cmd dd if=/dev/zero of=/dev/${TARGET_DISK} bs=512 count=1
+do_cmd vgchange -a n >&2 || exit ${Abort}
+do_cmd hdparm -z /dev/${TARGET_DISK}
+
+exit ${Continue}

--- a/part2/stages/Remove-partitions
+++ b/part2/stages/Remove-partitions
@@ -22,8 +22,8 @@
 . ${DISK_CONF}
 # ^^^ defines ${TARGET_DISK}
 
-do_cmd dd if=/dev/zero of=/dev/${TARGET_DISK} bs=512 count=1
+do_cmd dd if=/dev/zero of=/dev/${TARGET_DISK} bs=512 count=1 >&2
 do_cmd vgchange -a n >&2 || exit ${Abort}
-do_cmd hdparm -z /dev/${TARGET_DISK}
+do_cmd hdparm -z /dev/${TARGET_DISK} >&2
 
 exit ${Continue}

--- a/part2/stages/Warn-disk-erasure
+++ b/part2/stages/Warn-disk-erasure
@@ -26,7 +26,9 @@ if ! interactive ; then
 fi
 
 . ${DISK_CONF} # defines ${TARGET_DISK}
-. ${PARTITION_CONF} # defines ${PARTITION_MODE}
+#Always erase the entire disk until other functionality is implemented.
+#. ${PARTITION_CONF} # defines ${PARTITION_MODE}
+PARTITION_MODE="erase-entire-disk"
 
 MODEL=$(cat /sys/block/${TARGET_DISK}/device/model)
 RAW_SIZE=$(cat /sys/block/${TARGET_DISK}/size)

--- a/part2/stages/install-main.graph
+++ b/part2/stages/install-main.graph
@@ -5,10 +5,11 @@ Initialise-state,             Continue:Examine-repository | Abort:Unexpected-fai
 Examine-repository,           Continue:Find-existing-install | Abort:Unexpected-failure
 Find-existing-install,        Install:Select-hard-disk | Upgrade:Ready-to-upgrade | Abort:Fail
 
-Select-hard-disk,             Continue:Configure-partitions | Abort:Fail
+Select-hard-disk,             Continue:Warn-disk-erasure | Abort:Fail
+Warn-disk-erasure,            Continue:Remove-partitions | Abort:Fail
+Remove-partitions,            Continue:Configure-partitions | Abort:Fail
 Configure-partitions,         Continue:Configure-MBR | Abort:Fail
-Configure-MBR,                Continue:Warn-disk-erasure | Abort:Fail
-Warn-disk-erasure,            Continue:Set-password | Abort:Fail
+Configure-MBR,                Continue:Set-password | Abort:Fail
 
 Set-password,                 Continue:Enable-SSH | Abort:Fail
 Enable-SSH,                   Continue:TPM-Begin | Abort:Fail


### PR DESCRIPTION
The first commit fixes a couple bugs I encountered that made the installer unable to detect and remove partitions. OpenXT was actually able to install over Windows 10 after those fixes. However, it still had no capability to remove GPT partitions, so I went ahead with the plan to always overwrite the entire 512-byte MBR area.