### PR TITLE
OXT-1107: Cleanup LVM layout before wiping partition table.

### DIFF
--- a/part1/stages/Check-host-capabilities
+++ b/part1/stages/Check-host-capabilities
@@ -64,7 +64,7 @@ else
     echo 'VTd="False"' >>"${HOST_CAPABILITY_CONF}"
     warning=1
 fi
-echo ${msg} >&2
+echo -e ${msg} >&2
 
 if ! interactive ; then
     [ "${warning}" -ne "1" ] || echo -e "\nWARNING: $msg Check the BIOS settings.\n">&2

--- a/part2/stages/Find-existing-install
+++ b/part2/stages/Find-existing-install
@@ -34,7 +34,8 @@ detect_prior_installation()
     do_cmd vgs xenclient >&2 || return
 
     # read the version information from the detected filesystem:
-    mount_existing_dom0 "${EXISTING_DOM0_MOUNT}"
+    mount_existing_dom0 "${EXISTING_DOM0_MOUNT}" || return
+
     local EXISTING_VERSION_FILE="${EXISTING_DOM0_MOUNT}/etc/xenclient.conf"
     EXISTING_VERSION="$(sed -ne 's/^version = //p' <${EXISTING_VERSION_FILE})"
     EXISTING_RELEASE="$(sed -ne 's/^release = //p' <${EXISTING_VERSION_FILE})"

--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -846,6 +846,7 @@ mount_existing_dom0()
 {
     local MNT="$1"
 
+    [ -b "/dev/mapper/xenclient-root" ] || return 1
     CURRENT_MNT=$(grep "^/dev/mapper/xenclient-root " /proc/mounts |
                   cut -f2 -d' ')
 

--- a/part2/stages/Make-XC-partition
+++ b/part2/stages/Make-XC-partition
@@ -25,7 +25,6 @@
 mk_xc_partition_layout()
 {
     deactivate_lvm             || return 1
-    remove_existing_partitions || return 1
     create_xc_partition        || return 1
     return 0
 }
@@ -37,34 +36,6 @@ deactivate_lvm()
     if ! do_cmd vgchange -a n >&2 ; then
         echo "ERROR: Failure deactivating existing logical volumes." >&2
         return 1
-    fi
-    return 0
-}
-
-remove_existing_partitions()
-{
-    if [ "${REMOVE_PARTITIONS}" ] ; then
-        mixedgauge "Removing disk partitions..." 5
-
-        for P in ${REMOVE_PARTITIONS} ; do
-            local DISK=$(get_partition_disk "${P}")
-            local PARTITION_NUM=$(get_partition_number "${P}")
-            local NODE=$(get_partition_node "${P}")
-            local DISK_DEV="/dev/${DISK}"
-            local PARTITION_DEV="/dev/${NODE}"
-
-            # Ignore errors returned by pvremove here as there may not
-            # actually be any LVM state to remove. Any important failures
-            # here will also cause the later creation commands to fail, so
-            # handle errors there.
-            do_cmd pvremove -ff -y "${PARTITION_DEV}" >&2
-
-            do_cmd fdisk -u "${DISK_DEV}" <<EOF >&2
-d
-${PARTITION_NUM}
-w
-EOF
-        done
     fi
     return 0
 }

--- a/part2/stages/Remove-partitions
+++ b/part2/stages/Remove-partitions
@@ -22,6 +22,41 @@
 . ${DISK_CONF}
 # ^^^ defines ${TARGET_DISK}
 
+# Remove every VG assigned to that disk.
+vgs=$(vgs --noheading -o vg_name)
+for vg in ${vgs}; do
+    pvs_on_target=$(vgs --noheading -o pv_name ${vg} | grep ${TARGET_DISK})
+    pvs_others=$(vgs --noheading -o pv_name ${vg} | grep -v ${TARGET_DISK})
+
+    # Ignore VG not on the target disk.
+    if [ -z "${pvs_on_target}" ]; then
+        continue
+    fi
+
+    # If possible, try to move PE to non-targeted PV.
+    # Otherwise, assume the user is knowingly wiping the entire disk with every
+    # LV/VG on it (common use case involving only one disk).
+    if [ -n "${pvs_others}" ]; then
+        for pv in ${pvs_on_target}; do
+            if ! pvmove ${pv} ${pvs_others} >&2; then
+                # We should probably ask for confirmation here...
+                # Maybe this was done willingly.
+                exit ${Abort}
+            fi
+            # Remove each PV on the target disk from the VG.
+            do_cmd vgreduce ${vg} ${pv} >&2
+        done
+    else
+        # Every PV on the target disk, so wipe the VG.
+        do_cmd vgremove -f ${vg} >&2
+    fi
+
+    # Wipe labels on each PV.
+    for pv in ${pvs_on_target}; do
+        do_cmd pvremove -f ${pv} >&2
+    done
+done
+
 do_cmd dd if=/dev/zero of=/dev/${TARGET_DISK} bs=512 count=1 >&2
 do_cmd vgchange -a n >&2 || exit ${Abort}
 do_cmd hdparm -z /dev/${TARGET_DISK} >&2


### PR DESCRIPTION
- Attend a minor log issue,
- Do not assume there is an OpenXT installation when failing to mount xenclient-root (or when vg xenclient exist but has not xenclient-root), it makes logs cleaner,
- Discard deprecated logic to remove partitions and/or LVM layout since the MBR is wiped prior to that.
- Attempt, as cleanly as possible, to remove the LVM layout before wiping the MBR.