### PR TITLE
STABLE-7: OXT-1124: part2: Create /config/etc/lvm

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -230,6 +230,9 @@ install_dom0()
     do_cmd mkdir -p -m 500 ${DOM0_MOUNT}/config/keys        >&2 || return 1
     do_cmd mkdir -p -m 500 ${DOM0_MOUNT}/config/sec         >&2 || return 1
 
+    # prepare lvm directory to store lvm metadata backups.
+    do_cmd mkdir -p -m 755 ${DOM0_MOUNT}/config/etc/lvm     >&2 || return 1
+
     #
     # log
     #


### PR DESCRIPTION
postinstall scripts would normally create that, but the installer will
deploy images directly, so it has to be created.