### PR TITLE
[Stable-7] part2: add securityfs to dom0 mount

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -468,6 +468,8 @@ mount_dom0()
         tmpfsopts="$tmpfsopts,rootcontext=system_u:object_r:tmp_t:s0"
     fi
     do_mount -t tmpfs -o $tmpfsopts tmpfs ${DOM0_MOUNT}/tmp  || return 1
+    mount -t securityfs | grep -q -s 'securityfs' >&2
+    [ $? -eq 0 ] && ( do_mount -o bind /sys/kernel/security ${DOM0_MOUNT}/sys/kernel/security || return 1 )
     mount -t selinuxfs | grep -q -s 'selinuxfs' >&2
     [ $? -eq 0 ] && ( do_mount -o bind /selinux ${DOM0_MOUNT}/selinux || return 1 )
     # FIXME - revisit this for XC-5161:


### PR DESCRIPTION
The securityfs mount is not carried through with the sysfs bind mount, so add it explicitly.

OXT-1004

Signed-off-by: Daniel P. Smith dpsmith@apertussolutions.com