### PR TITLE
Inhibit forward seal for non-OTA upgrades

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -496,14 +496,8 @@ mount_config()
         else
             echo "mount_config: ERROR luksOpen-ing /dev/xenclient/config" >&2
         fi
-    else # not already mounted, mapped and platform state is sealed
-        recovery_unlock "/dev/xenclient/config" config "${DOM0_MOUNT}" >&2
-        if [ $? -eq 0 ]; then
-            echo "mount_config: config mapped successfully, mounting" >&2
-            do_mount /dev/mapper/config ${DOM0_MOUNT}/config || return 1
-        else
-            echo "mount_config: ERROR luksOpen-ing /dev/xenclient/config" >&2
-        fi
+    else # not already mounted or mapped and platform state is sealed
+        return 1
     fi
 
     return 0


### PR DESCRIPTION
This removes the code that would attempt to unlock the config logical volume during install/upgrade. This will cause forward seal to silently fail when the config partition is not already unlocked/mounted, e.g. not an OTA.

OXT-1043, OXT-1131

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>