### PR TITLE
STABLE-7: OXT-1185: lvm: Support arguments for different versions

### DIFF
--- a/common/stages/Functions/library
+++ b/common/stages/Functions/library
@@ -342,3 +342,31 @@ get_partition_node()
 
     return 0
 }
+
+#-----------------------------------------------------------
+# Usage: version_ge <v1> <v2>
+# Parse and compare versions formatted as "major.minor.micro".
+# Return 0 if v1 >= v2, else return 1.
+version_ge() {
+    local v1=$1
+    local v2=$2
+
+    local v1_maj="${v1%%.*}"
+    local __v1_min="${v1#*.}"
+    local v1_min="${__v1_min%%.*}"
+    local v1_mic="${v1%%.*}"
+
+    local v2_maj="${v2%%.*}"
+    local __v2_min="${v2#*.}"
+    local v2_min="${__v2_min%%.*}"
+    local v2_mic="${v2%%.*}"
+
+    if [ $(($v1_maj - $v2_maj)) -ne 0 ]; then
+        return [ $v1_maj -ge $v2_maj ]
+    elif [ $(($v1_min - $v2_min)) -ne 0 ]; then
+        return [ $v1_min -ge $v2_min ]
+    else
+        return [ $v1_mic -ge $v2_mic ]
+    fi
+}
+

--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -20,23 +20,30 @@
 mk_xc_lvm()
 {
     local PARTITION_DEV="$1"
+    local LVM_VERSION="$(lvcreate --version | sed -ne 's/\s\+LVM version:\s\+\([^0-9.]*\([0-9.]*\)\).*/\1/p')"
+    local LVM_OPTS="--zero y --yes"
+
+    if version_ge ${LVM_VERSION} "2.02.105"; then
+        LVM_OPTS="${LVM_OPTS} --wipesignatures y"
+    fi
+
     do_cmd pvcreate -ff -y "${PARTITION_DEV}" || return 1
     do_cmd vgcreate xenclient "${PARTITION_DEV}" || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
+    do_cmd lvcreate ${LVM_OPTS} \
                     --name boot --size 12M /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
+    do_cmd lvcreate ${LVM_OPTS} \
                     --name config --size 12M /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
+    do_cmd lvcreate ${LVM_OPTS} \
                     --name root --size ${DOM0_ROOT_LV_SIZE} /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
+    do_cmd lvcreate ${LVM_OPTS} \
                     --name root.new --size ${DOM0_ROOT_LV_SIZE} /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
+    do_cmd lvcreate ${LVM_OPTS} \
                     --name swap --size 256M /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
+    do_cmd lvcreate ${LVM_OPTS} \
                     --name log --size 64M /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
+    do_cmd lvcreate ${LVM_OPTS} \
                     --name cores --size 64M /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
+    do_cmd lvcreate ${LVM_OPTS} \
                     --name storage -l +100%FREE /dev/xenclient || return 1
     do_cmd lvresize -f /dev/xenclient/storage -L-1G || return 1
 


### PR DESCRIPTION
wipesignatures was introduced on 2.02.105, it should not be passed for
earlier versions.