### PR TITLE
STABLE-7: OXT-1185: OTA upgrade 6 to 7

### DIFF
--- a/common/stages/Functions/library
+++ b/common/stages/Functions/library
@@ -342,3 +342,31 @@ get_partition_node()
 
     return 0
 }
+
+#-----------------------------------------------------------
+# Usage: version_ge <v1> <v2>
+# Parse and compare versions formatted as "major.minor.micro".
+# Return 0 if v1 >= v2, else return 1.
+version_ge() {
+    local v1=$1
+    local v2=$2
+
+    local v1_maj="${v1%%.*}"
+    local __v1_min="${v1#*.}"
+    local v1_min="${__v1_min%%.*}"
+    local v1_mic="${v1##*.}"
+
+    local v2_maj="${v2%%.*}"
+    local __v2_min="${v2#*.}"
+    local v2_min="${__v2_min%%.*}"
+    local v2_mic="${v2##*.}"
+
+    if [ $(($v1_maj - $v2_maj)) -ne 0 ]; then
+        [ $v1_maj -ge $v2_maj ]
+    elif [ $(($v1_min - $v2_min)) -ne 0 ]; then
+        [ $v1_min -ge $v2_min ]
+    else
+        [ $v1_mic -ge $v2_mic ]
+    fi
+}
+

--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -17,27 +17,36 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
+create_lv() {
+    local dfl_opts="--zero y"
+    local vg=$1
+    local name=$2
+    shift 2
+    local opts=$@
+
+    local version="$(lvcreate --version | sed -ne 's/\s\+LVM version:\s\+\([^0-9.]*\([0-9.]*\)\).*/\1/p')"
+    if version_ge ${version} "2.02.105"; then
+        dfl_opts="${dfl_opts} --wipesignatures y --yes"
+    fi
+
+    lvcreate ${dfl_opts} --name ${name} ${opts} ${vg}
+}
+
 mk_xc_lvm()
 {
     local PARTITION_DEV="$1"
+
     do_cmd pvcreate -ff -y "${PARTITION_DEV}" || return 1
     do_cmd vgcreate xenclient "${PARTITION_DEV}" || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
-                    --name boot --size 12M /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
-                    --name config --size 12M /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
-                    --name root --size ${DOM0_ROOT_LV_SIZE} /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
-                    --name root.new --size ${DOM0_ROOT_LV_SIZE} /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
-                    --name swap --size 256M /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
-                    --name log --size 64M /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
-                    --name cores --size 64M /dev/xenclient || return 1
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
-                    --name storage -l +100%FREE /dev/xenclient || return 1
+    do_cmd create_lv xenclient boot --size 12M || return 1
+    do_cmd create_lv xenclient config --size 12M || return 1
+    do_cmd create_lv xenclient root --size ${DOM0_ROOT_LV_SIZE} || return 1
+    do_cmd create_lv xenclient root.new --size ${DOM0_ROOT_LV_SIZE} || return 1
+    do_cmd create_lv xenclient swap --size 256M || return 1
+    do_cmd create_lv xenclient log --size 64M || return 1
+    do_cmd create_lv xenclient cores --size 64M || return 1
+    do_cmd create_lv xenclient storage -l +100%FREE || return 1
+
     do_cmd lvresize -f /dev/xenclient/storage -L-1G || return 1
 
     do_cmd vgscan --mknodes || return 1
@@ -334,10 +343,11 @@ upgrade_dom0()
     DOM0_SIZE_BYTES=$(zcat ${DOM0_ROOTFS} | wc -c)
     DOM0_ROOT_LV_SIZE=$(((${DOM0_SIZE_BYTES} / 1048576) + 1))M
 
-    do_cmd lvcreate --wipesignatures y --zero y --yes \
-                    --name `basename ${ROOT_DEV}.new` \
-                    --size ${DOM0_ROOT_LV_SIZE}  \
-                    `dirname ${ROOT_DEV}.new` >&2 || return 1
+    local ROOT_LV="$(lvs --noheadings -o lv_name ${ROOT_DEV})"
+    local ROOT_VG="$(lvs --noheadings -o vg_name ${ROOT_DEV})"
+
+    do_cmd create_lv "${ROOT_VG}" "${ROOT_LV}.new" \
+        --size ${DOM0_ROOT_LV_SIZE} >&2 || return 1
     write_rootfs ${DOM0_ROOTFS} ${ROOTFS_TYPE} ${ROOT_DEV}.new >&2 || {
         do_cmd lvremove -f ${ROOT_DEV}.new >&2
         return 1

--- a/part2/stages/Unlock-config
+++ b/part2/stages/Unlock-config
@@ -18,13 +18,8 @@
 
 . ${SCRIPT_DIR}/functions
 . ${SCRIPT_DIR}/Functions/install-main
-. /usr/lib/openxt/key-functions
 
 not_previous || exit ${Previous}
-
-if ! keystore_ready; then
-    setup_keystore || exit ${Abort}
-fi
 
 # test_recovery_key needs the boot partition to check for the old XC scheme,
 # so we have to mount it.
@@ -42,7 +37,21 @@ check_recovery_key() {
 }
 
 # OTA Upgrade doesn't need a key
+# OTA Upgrade from 6 -> 7 should ${Continue} here.
+#   OpenXT 6 did not have the key-management and measured-launch refactoring,
+#   hence no /usr/lib/openxt/key-functions. If config happens to not be mounted
+#   at this point, abort as this upgrade path is not supported.
 is_mounted /config && exit ${Continue}
+
+if [ -e /usr/lib/openxt/key-functions ]; then
+    . /usr/lib/openxt/key-functions
+else
+    exit ${Abort}
+fi
+
+if ! keystore_ready; then
+    setup_keystore || exit ${Abort}
+fi
 
 if have_recovery_key ; then
     check_recovery_key && exit ${Continue}


### PR DESCRIPTION
With the part2 installer from OpenXT 7 being run on an OpenXT 6 dom0, some retro-compatibility has to be dealt with in the installer.
- lvm was upgraded and some new arguments were not implemented in previous versions (2.02.85 -> 2.02.105).
- the key-management and ml-measurement scripts were added with OpenXT 7, and came with changes to the installer that are not retro-compatible on an OpenXT 6 dom0 image.