### PR TITLE
STABLE-7: OXT-1130: Reuse owned TPM2

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -923,8 +923,7 @@ is_mounted()
 }
 
 # take ownership of TPM if necessary
-own_tpm()
-{
+own_tpm() {
     if [ "${TPM_STATE}" != "active" ]; then
         echo "TPM sate not active, canot own_tpm" >&2
         return 1
@@ -938,6 +937,15 @@ own_tpm()
             echo "taking tpm ownership failed" >&2
             return 1
         fi
+    fi
+
+    if ! tpm_handles_defined; then
+        local err
+
+        err=$( tpm_create_handles "${own_key}" ) || {
+            echo "error creating TPM handles: ${err}" >&2
+            return 1
+        }
     fi
 
     generate_policy "${own_key}"


### PR DESCRIPTION
Stable-7 version.

This PR adds support for reusing an owned TPM2. The actual password check is implemented in https://github.com/OpenXT/xenclient-oe/pull/745. The installer needs to re-create the TPM2 objects handles if necessary.

Depends on https://github.com/OpenXT/xenclient-oe/pull/745

OXT-1130