### PR TITLE
STABLE-7: OXT-1194: TPM-Check: Do not prompt the user empty messages.

### DIFF
--- a/part2/stages/TPM-Check
+++ b/part2/stages/TPM-Check
@@ -70,7 +70,9 @@ log_tpm_attrs() {
 }
 
 quirk_callback () {
-    interactive && dialog --ok-label Continue --msgbox "$1" 0 0
+    if interactive && [ -n "$1" ]; then
+        dialog --ok-label Continue --msgbox "$1" 0 0
+    fi
 }
 
 quirk_fatal_callback () {


### PR DESCRIPTION
During part2/TPM-Check, using the TPM2.0 Dell firmware quirk or not for
measurment should not prompt the user, waiting for an input, to confirm
the quirk is used.
quirk_detect should not prompt the dialog box if the called script has
nothing to say.

Depends on: https://github.com/OpenXT/xenclient-oe/pull/750.