### PR TITLE
OXT-1286: LVM Physical Volume an Volume Group removal

### DIFF
--- a/common/stages/Functions/library
+++ b/common/stages/Functions/library
@@ -381,3 +381,18 @@ selinux_enforced() {
         return 1
     fi
 }
+
+#-----------------------------------------------------------
+# Usage: reread_partition_table
+# Return 0 when the table is read successfuly, an error code otherwise.
+reread_partition_table()
+{
+    local dev="$1"
+
+    echo "Re-read partition table." >&2
+    vgchange -a n >&2
+    hdparm -z "${dev}" >&2
+    vgchange -a y >&2
+    udevadm settle >&2
+}
+

--- a/part1/stages/Status-report
+++ b/part1/stages/Status-report
@@ -41,7 +41,7 @@ dialog --no-cancel --editbox /tmp/install-fail.txt 15 70 2>${INSTALL_DATA}/user-
 hide_cursor
 
 # Eventually remounts required file systems read-only to recover logs
-do_cmd vgscan --mknodes >&2
+do_cmd vgscan >&2
 do_cmd vgchange -a y >&2
 
 mkdir -p ${STATUS_MOUNT}

--- a/part2/stages/Remove-partitions
+++ b/part2/stages/Remove-partitions
@@ -80,7 +80,6 @@ done
 
 # Remove GPT partition table
 do_cmd sgdisk -Z /dev/${TARGET_DISK} >&2
-do_cmd vgchange -a n >&2 || exit ${Abort}
-do_cmd hdparm -z /dev/${TARGET_DISK} >&2
+reread_partition_table "/dev/${TARGET_DISK}"
 
 exit ${Continue}

--- a/part2/stages/Remove-partitions
+++ b/part2/stages/Remove-partitions
@@ -24,9 +24,30 @@
 
 # Remove every VG assigned to that disk.
 vgs=$(vgs --noheading -o vg_name)
+if [ -L ${TARGET_DISK} ]; then
+    dev="/dev/$(readlink ${TARGET_DISK})"
+else
+    dev="${TARGET_DISK}"
+fi
 for vg in ${vgs}; do
-    pvs_on_target=$(vgs --noheading -o pv_name ${vg} | grep ${TARGET_DISK})
-    pvs_others=$(vgs --noheading -o pv_name ${vg} | grep -v ${TARGET_DISK})
+    # List all PV backing current VG.
+    pvs="$(vgs --noheading -o pv_name ${vg})"
+    pvs_on_target=""
+    pvs_others=""
+    for p in ${pvs}; do
+        if [ -L "${p}" ]; then
+            # NVMe will sometimes appear as symlinks to the actual device in
+            # the devfs (e.g: /dev/512GB_ -> nvme0n1p1).
+            dev="/dev/$(readlink ${p})"
+        else
+            dev="${p##/dev}"
+        fi
+        if [ "${dev##${TARGET_DISK}}" != "${dev}" ]; then
+            pvs_on_target="${pvs_of_vg} ${dev}"
+        else
+            pvs_others="${pvs_of_vg} ${dev}"
+        fi
+    done
 
     # Ignore VG not on the target disk.
     if [ -z "${pvs_on_target}" ]; then


### PR DESCRIPTION
This was initially part of https://github.com/OpenXT/installer/pull/65 and got lost during rebase.

Fix installation on NVMe drives by handling devfs symlink naming conventions in the `Remove-partitions` stage. Introduce `reread_partition_table` to handle LVM `vgchange -a -n`.