### PR TITLE
Allow udev to settle after the lvcreate

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -30,6 +30,7 @@ create_lv() {
     fi
 
     lvcreate ${dfl_opts} --name ${name} ${opts} ${vg}
+    udevadm settle
 }
 
 mk_xc_lvm()


### PR DESCRIPTION
Signed-off-by: Richard Turner <turnerr@ainfosec.com>

Without the udev settling, follow-on lvcreate calls will sometimes error with "Aborting. Failed to activate new LV to wipe the start of it." This problem can occur randomly during initial provisioning after multiple lvcreate calls, such as in the mk_xc_lvm function. This problem is completely dependent on how udev responds. This change proposes waiting until all of the udev events are cleared before creating another logical volume. 