### PR TITLE
OXT-1298: install-main: Wait on ROOT_DEV appearance

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -385,6 +385,9 @@ commit_dom0()
         return 1
     }
 
+    # Give udev a chance to create ${ROOT_DEV}
+    do_cmd udevadm settle
+
     mount_dom0 "${ROOT_DEV}" || return 1
 
     do_cmd mkdir -p ${DOM0_MOUNT}/storage/disks || return 1


### PR DESCRIPTION
There seems to be a delay after lvrename completed before udev creates
the new block device node.  Sometimes the installer fails because it
tries to mount $ROOT_DEV before the device node is present.  Loop for a
maximum of 10 seconds to give time for it to appear.

A simple sleep 1 seems sufficient in testing, but that is fragile.

OXT-1298

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

I'm not super thrilled with this approach, but this failure bit me a bunch today.  Re-running installations got old fast.