### PR TITLE
OXT-1321: fbcon: The module is now builtin.

### DIFF
--- a/part1/stages/Initialise-state
+++ b/part1/stages/Initialise-state
@@ -49,8 +49,4 @@ mkdir -p "${INSTALL_SOURCE_DIR}"
 # Preserve a copy of the kernel command line
 cat </proc/cmdline >${KCMD_LINE}
 
-# if we're using linuxfb graphics (from grub) rather than mode 3
-# we need to enable text mode here. no-op for non graphical installs
-modprobe fbcon || true
-
 exit ${Continue}


### PR DESCRIPTION
Silence warning:
modprobe: FATAL: Module fbcon not found in directory /lib/modules/4.14.34

Complements https://github.com/OpenXT/xenclient-oe/pull/901