### PR TITLE
STABLE-8: OXT-1298: install-main: Wait on ROOT_DEV appearance

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -385,6 +385,9 @@ commit_dom0()
         return 1
     }
 
+    # Give udev a chance to create ${ROOT_DEV}
+    do_cmd udevadm settle
+
     mount_dom0 "${ROOT_DEV}" || return 1
 
     do_cmd mkdir -p ${DOM0_MOUNT}/storage/disks || return 1


### PR DESCRIPTION
This is the Stable-8 version of https://github.com/OpenXT/installer/pull/73

There seems to be a delay between lvrename completing and udev creating
the new block device node.  Sometimes the installer fails because it
tries to mount $ROOT_DEV before the device node is present.  Use udevadm
settle to wait on any pending udev changes.

OXT-1298

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit cf09fcf979b17abd229272d7dfe2a523764a222e)
