### PR TITLE
STABLE-8: OXT-1357: Restrict TPM messages to measured launch

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -399,13 +399,13 @@ commit_dom0()
 
     install_bootloader_from_dom0fs || return 1
 
-    mixedgauge "Taking ownership of TPM" 50
-
     if [ "${MEASURE_LAUNCH}" = "true" ]; then
-        own_tpm || return 1
-    fi
+        mixedgauge "Taking ownership of TPM" 50
 
-    mixedgauge "Taking ownership of TPM" 100
+        own_tpm || return 1
+
+        mixedgauge "Taking ownership of TPM" 100
+    fi
 
     # handle refresh cases & measured launch misery
     if [ "${INSTALL_MODE}" = "upgrade" ]; then


### PR DESCRIPTION
It's surprising to see "Taking ownership of TPM" during a non-measured
launch install.  Move those messages inside the conditional block so
they are only printed when appropriate.

OXT-1357

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 5fd306094d3c6fc5cf9d9f862fdfefe32f6e5aed)

Stable-8 version of https://github.com/OpenXT/installer/pull/82