### PR TITLE
STABLE-8: UEFI Fixes

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -540,10 +540,22 @@ install_bootloader_from_dom0fs()
     return 0
 }
 
+remove_efi_boot_entries()
+{
+    echo "Removing any existing OpenXT bootloader entries" >&2
+    for entry in $( efibootmgr | awk '/ OpenXT/ { print $1 }' ); do
+        entry=${entry%\*}
+        entry=${entry#Boot}
+        do_cmd efibootmgr -B -b $entry >&2
+    done
+}
+
 create_efi_boot_entries()
 {
     local DISK_DEV="$( echo ${1} | sed -e 's/[[:digit:]]*$//' )"
     local PART="${1#$DISK_DEV}"
+
+    remove_efi_boot_entries
 
     do_cmd efibootmgr -w -L "OpenXT (safe graphics)" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part ${PART} -u "openxt-support-safe-graphics" >&2
     if [ "$?" != "0" ]; then

--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -542,33 +542,34 @@ install_bootloader_from_dom0fs()
 
 create_efi_boot_entries()
 {
-    local DISK_DEV="/dev/${TARGET_DISK}"
+    local DISK_DEV="$( echo ${1} | sed -e 's/[[:digit:]]*$//' )"
+    local PART="${1#$DISK_DEV}"
 
-    do_cmd efibootmgr -w -L "OpenXT (safe graphics)" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part 1 -u "openxt-support-safe-graphics" >&2
+    do_cmd efibootmgr -w -L "OpenXT (safe graphics)" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part ${PART} -u "openxt-support-safe-graphics" >&2
     if [ "$?" != "0" ]; then
         echo "Couldn't create EFI boot entry" >&2
         return 1
     fi
 
-    do_cmd efibootmgr -w -L "OpenXT (AMT)" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part 1 -u "openxt-support-amt" >&2
+    do_cmd efibootmgr -w -L "OpenXT (AMT)" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part ${PART} -u "openxt-support-amt" >&2
     if [ "$?" != "0" ]; then
         echo "Couldn't create EFI boot entry" >&2
         return 1
     fi
 
-    do_cmd efibootmgr -w -L "OpenXT (console)" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part 1 -u "openxt-support-console" >&2
+    do_cmd efibootmgr -w -L "OpenXT (console)" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part ${PART} -u "openxt-support-console" >&2
     if [ "$?" != "0" ]; then
         echo "Couldn't create EFI boot entry" >&2
         return 1
     fi
 
-    do_cmd efibootmgr -w -L "OpenXT (console AMT)" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part 1 -u "openxt-support-console-amt" >&2
+    do_cmd efibootmgr -w -L "OpenXT (console AMT)" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part ${PART} -u "openxt-support-console-amt" >&2
     if [ "$?" != "0" ]; then
         echo "Couldn't create EFI boot entry" >&2
         return 1
     fi
 
-    do_cmd efibootmgr -w -L "OpenXT" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part 1 >&2
+    do_cmd efibootmgr -w -L "OpenXT" -l "\EFI\OpenXT\shimx64.efi" -c -d ${DISK_DEV} --part ${PART} >&2
     if [ "$?" != "0" ]; then
         echo "Couldn't create EFI boot entry" >&2
         return 1
@@ -627,7 +628,7 @@ copy_to_esp()
     do_cmd umount ${ESP_MOUNT} >&2
 
     if [ -d /sys/firmware/efi/efivars ]; then
-        create_efi_boot_entries
+        create_efi_boot_entries ${ESP}
         return $?
     fi
 


### PR DESCRIPTION
This is the stable-8 version of https://github.com/OpenXT/installer/pull/78

OXT-1344
Manually running the installer for upgrade fails in create_efi_boot_entries running efibootmgr because TARGET_DISK is unset. We really want the ESP partition, and we already have that in the calling function, copy_to_esp, so pass it in.

OXT-1328
Add remove_efi_boot_entries to remove already existing OpenXT bootloader entries. Otherwise duplicate entries are created each time OpenXT is re-installed over itself. The existing call to efibootmgr -D removes duplicates from the BootOrder Variable - not duplicate entries.