### PR TITLE
STABLE-8: OXT-1349: Configure-partitions: Restore erase-entire-disk folding

### DIFF
--- a/part2/stages/Configure-partitions
+++ b/part2/stages/Configure-partitions
@@ -377,9 +377,6 @@ partition_mode_is_unique()
         use-free-space)
             ;;
 
-        erase-entire-disk)
-            ;;
-
         erase-non-oem)
             # Check if equivalent to "erase-entire-disk".
             if [ -z "${OEM_PARTITIONS}" ] ; then
@@ -397,6 +394,23 @@ partition_mode_is_unique()
             if [ -z "${XC_PARTITION}" -a \
                  "${HAVE_UNUSED_PARTITION}" = "true" -a \
                  "${HAVE_FREE_SPACE}" = "true" ] ; then
+                return 1
+            fi
+            ;;
+
+        erase-entire-disk)
+            # Check if equivalent to "overwrite".
+            if [ "${XC_PARTITION}" -a \
+                 -z "${OEM_PARTITIONS}" -a \
+                 -z "${OTHER_PARTITIONS}" -a \
+                 "${HAVE_FREE_SPACE}" != "true" ] ; then
+                return 1
+            fi
+
+            # Check if equivalent to "use-free-space".
+            if [ -z "${XC_PARTITION}" -a \
+                 -z "${OEM_PARTITIONS}" -a \
+                 -z "${OTHER_PARTITIONS}" ] ; then
                 return 1
             fi
             ;;


### PR DESCRIPTION
This is the stable-8 version of https://github.com/OpenXT/installer/pull/81

Commit 86242803de16d5341b76c222f2e8ba785c48ce76 removed coalescing of
erase-entire-disk in partition_mode_is_unique.  Without this,
Configure-partitions presents an extra prompt in interactive mode for a
legacy boot between use-free-space and erase-entire-disk.  This is not
seen for UEFI boots since that provides an answerfile specifying
partition-mode erase-entire-disk bypassing the prompt even in
interactive mode.

Restore the coalescing to bypass the superfluous prompt.

This reverts part of 86242803de16d5341b76c222f2e8ba785c48ce76

OXT-1349

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 0e686df4d2a9c5711dde3533151bf0d1b815c0dc)