### PR TITLE
STABLE-8: OXT-1351: Change PCR Sealing selection on upgrade

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -447,6 +447,9 @@ seal_system() {
             if is_mounted ${DOM0_MOUNT}/config ; then
                 echo "seal_system: /config is mounted, forward sealing key" >&2
 
+                # Update config.pcrs in case it has changed
+                write_config_pcrs "${DOM0_MOUNT}"
+
                 /etc/init.d/trousers stop
                 chroot ${DOM0_MOUNT} /usr/sbin/seal-system -f -r ${ROOT_DEV}
                 /etc/init.d/trousers start


### PR DESCRIPTION
This is the stable-8 version of https://github.com/OpenXT/installer/pull/80

If we are upgrading, we must write out /config/config.pcrs to ensure new
values in case the PCR selection changed.

OXT-1351

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit e863a010aaf620734c1c308854104881e3314082)

Depends on https://github.com/OpenXT/xenclient-oe/pull/934