### PR TITLE
STABLE-8: installer: tftp server may not be dhcp default.

### DIFF
--- a/common/stages/Functions/fetch
+++ b/common/stages/Functions/fetch
@@ -84,8 +84,12 @@ fetch_file_tftp()
     local REMOTE_LEAF=$(echo "${SOURCE_URL}" | \
                         sed -e 's,^tftp://[^/]*/,,g' )
 
-    [ -z "${REMOTE_HOST}" ] && REMOTE_HOST="dhcp"
-    local DHCP_PREFIX=$(cat /etc/dhcp-prefix)
+    if [ -z "${REMOTE_HOST}" ]; then
+        REMOTE_HOST="dhcp"
+    fi
+    if [ "${REMOTE_HOST}" = "dhcp" ]; then
+        DHCP_PREFIX=$(cat /etc/dhcp-prefix)
+    fi
 
     do_cmd tftp -l "${TARGET_FILE}" \
                 -r "${DHCP_PREFIX}/${REMOTE_LEAF}" \


### PR DESCRIPTION
This configuration could happen when chaining network boot to a
different server. /etc/dhcp-prefix in this case will not be relevant to
the new given tftp server.
In general it seems using /etc/dhcp-prefix is relevant when accessing
the tftp server given by the DHCP server (option 210?). This is obvious
when accessing tftp://dhcp/<path>.

(cherry picked from commit a25f6ab2cbd0e6936a4a85ab08b085282688a961)