### PR TITLE
STABLE-8: [upgrade] Increase tpmfs size and unmount all fs

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -436,11 +436,7 @@ seal_system() {
 
             mount_config || {
                 echo "failed to mount config" >&2
-                do_umount ${DOM0_MOUNT}/boot/system
-                do_umount ${DOM0_MOUNT}/tmp
-                do_umount ${DOM0_MOUNT}/dev
-                do_umount ${DOM0_MOUNT}/sys
-                do_umount ${DOM0_MOUNT}
+                do_umount_all ${DOM0_MOUNT}
                 return 1
             }
 
@@ -454,23 +450,12 @@ seal_system() {
                 chroot ${DOM0_MOUNT} /usr/sbin/seal-system -f -r ${ROOT_DEV}
                 /etc/init.d/trousers start
 
-                do_umount ${DOM0_MOUNT}/config
-                do_umount ${DOM0_MOUNT}/boot/system
-                do_umount ${DOM0_MOUNT}/tmp
-                do_umount ${DOM0_MOUNT}/dev
-                do_umount ${DOM0_MOUNT}/sys
-                do_umount ${DOM0_MOUNT}/proc
-                do_umount ${DOM0_MOUNT}
+                do_umount_all ${DOM0_MOUNT}
 
                 return 0
             fi
 
-            do_umount ${DOM0_MOUNT}/boot/system
-            do_umount ${DOM0_MOUNT}/tmp
-            do_umount ${DOM0_MOUNT}/dev
-            do_umount ${DOM0_MOUNT}/sys
-            do_umount ${DOM0_MOUNT}/proc
-            do_umount ${DOM0_MOUNT}
+            do_umount_all ${DOM0_MOUNT}
             return 1
         fi
     fi
@@ -479,7 +464,7 @@ seal_system() {
 mount_dom0()
 {
     local ROOT="$1"
-    local tmpfsopts="size=32M"
+    local tmpfsopts="size=64M"
     if selinux_enforced ; then
         tmpfsopts="$tmpfsopts,rootcontext=system_u:object_r:tmp_t:s0"
     fi


### PR DESCRIPTION
  The initramfs.gz is too large for the old 32M sized tmpfs,
  as hash_module must first extract the compressed .gz. Also
  some bind mounts were left hanging after upgrade completed,
  make sure we umount them in the proper order.

Signed-off-by: Chris <rogersc@ainfosec.com>
(cherry picked from commit fe3ca1bf256b988dab01972d1b77d8d6bbd94db1)
Signed-off-by: Jed <lejosnej@ainfosec.com>