### PR TITLE
STABLE-8: OXT-1372: installer: Amend disk/partition for efibootmgr

### DIFF
--- a/common/stages/Functions/library
+++ b/common/stages/Functions/library
@@ -396,3 +396,30 @@ reread_partition_table()
     udevadm settle >&2
 }
 
+#-----------------------------------------------------------
+# Usage: get_devnode_disk /dev/(sd[a-z]\+[0-9]\+|/dev/nvme[0-9]\+n[0-9]\+p[0-9]\+)
+# Prints the disk component of the argument devnode on stdout.
+get_devnode_disk() {
+    local devnode="$1"
+    local disk
+
+    case "${devnode}" in
+        "/dev/nvme"*) disk="${devnode%p*}" ;;
+        "/dev/sd"*)   disk="${devnode%%[!/a-z]*}" ;;
+    esac
+    echo "${disk}"
+}
+
+#-----------------------------------------------------------
+# Usage: get_devnode_partition /dev/(sd[a-z]\+[0-9]\+|/dev/nvme[0-9]\+n[0-9]\+p[0-9]\+)
+# Prints the partition component of the argument devnode on stdout.
+get_devnode_partition() {
+    local devnode="$1"
+    local part
+
+    case "${devnode}" in
+        "/dev/nvme"*"p"*) part="${devnode##*nvme*n*p}" ;;
+        "/dev/sd"*)       part="${devnode##*/sd*[!0-9]}" ;;
+    esac
+    echo "${part}"
+}

--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -540,8 +540,9 @@ remove_efi_boot_entries()
 
 create_efi_boot_entries()
 {
-    local DISK_DEV="$( echo ${1} | sed -e 's/[[:digit:]]*$//' )"
-    local PART="${1#$DISK_DEV}"
+    local DEVNODE="$1"
+    local DISK_DEV="$(get_devnode_disk ${DEVNODE})"
+    local PART="$(get_devnode_partition ${DEVNODE})"
 
     remove_efi_boot_entries
 


### PR DESCRIPTION
Add two functions to the common script library to parse devnodes disk
and partition and use them with efibootmgr when writting efi boot
entries for a new OpenXT installation.

(cherry picked from commit 864c5077675a725861a5633e0bd28bf31c24db35)
Master PR: https://github.com/OpenXT/installer/pull/92
