### PR TITLE
OXT-1376: installer: Don't create new boot entries on upgrade

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -628,7 +628,7 @@ copy_to_esp()
 
     do_cmd umount ${ESP_MOUNT} >&2
 
-    if [ -d /sys/firmware/efi/efivars ]; then
+    if [ "${INSTALL_MODE}" = "fresh" ] && [ -d /sys/firmware/efi/efivars ]; then
         create_efi_boot_entries ${ESP}
         return $?
     fi


### PR DESCRIPTION
Dom0 doesn't ship with the efibootmgr binary. If we're
upgrading, just leave the boot entries as is.

OXT-1376