### PR TITLE
STABLE-9: part2: Add support for gunzip-ing files

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -90,7 +90,7 @@ apply_xc_packages()
                 install_syncvm "${PACKAGE_FILE}" "${PACKAGE_TYPE}"
                 ;;
             file)
-                install_file "${PACKAGE_FILE}" "${DESTINATION}"
+                install_file "${PACKAGE_FILE}" "${DESTINATION}" "${PACKAGE_TYPE}"
                 ;;
             upgrade-compat)
                 mixedgauge "Installing upgrade-comat (please wait)...." 85
@@ -951,10 +951,15 @@ install_file()
 
     local SRC="$1"
     local DST="$2"
+    local PACKAGE_TYPE="$3"
 
     mkdir -p $(dirname "${DOM0_MOUNT}/${DST}") || return 1
     rm -f "${DOM0_MOUNT}/${DST}.new" 2>/dev/null # ignore errors on this command.
-    cp "${SRC}" "${DOM0_MOUNT}/${DST}.new" || return 1
+    if [ "${PACKAGE_TYPE}" = "gz" ] ; then
+        do_cmd gunzip -c "${SRC}" > "${DOM0_MOUNT}/${DST}.new" || return 1
+    else
+        cp "${SRC}" "${DOM0_MOUNT}/${DST}.new" || return 1
+    fi
 
     return 0
 }


### PR DESCRIPTION
We can't easily gunzip and install a random file like a compressed
servicevm disk image.  Add support for "gz" PACKAGE_TYPE to file.  This
way a compressed file can be extracted and installed directly from the
installer.

add to the manifest file:
file gz required servicevm.vhd.gz /storage/disks/servicevm.vhd

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit 5423a2cb29d5bec181cffa09679666046c814a55)