### PR TITLE
STABLE-9: compat error checking additions

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -479,7 +479,7 @@ seal_system() {
                 write_config_pcrs "${DOM0_MOUNT}"
 
                 if [ "$(uname -m)" = "i686" ]; then
-                    mount_upgrade_compat
+                    mount_upgrade_compat || return 1
                     do_cmd /etc/init.d/trousers stop >&2
                     do_cmd chroot ${UPGRADE_MOUNT} \
                         /usr/sbin/seal-system -f -r ${ROOT_DEV} >&2
@@ -613,7 +613,7 @@ mount_config()
 install_bootloader_from_dom0fs()
 {
     if [ "$(uname -m)" = "i686" ]; then
-        mount_upgrade_compat
+        mount_upgrade_compat || return 1
         do_cmd chroot ${UPGRADE_MOUNT} \
                /usr/share/xenclient/install-bootloader "${LANGUAGE}" >&2 || {
             echo "Error installing the bootloader">&2

--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -480,15 +480,17 @@ seal_system() {
 
                 if [ "$(uname -m)" = "i686" ]; then
                     mount_upgrade_compat
-                    /etc/init.d/trousers stop
-                    chroot ${UPGRADE_MOUNT} /usr/sbin/seal-system -f -r ${ROOT_DEV}
-                    /etc/init.d/trousers start
+                    do_cmd /etc/init.d/trousers stop >&2
+                    do_cmd chroot ${UPGRADE_MOUNT} \
+                        /usr/sbin/seal-system -f -r ${ROOT_DEV} >&2
+                    do_cmd /etc/init.d/trousers start >&2
                     umount_upgrade_compat
-                    do_cmd lvremove -f /dev/xenclient/upgradecompat
+                    do_cmd lvremove -f /dev/xenclient/upgradecompat >&2
                 else
-                    /etc/init.d/trousers stop
-                    chroot ${DOM0_MOUNT} /usr/sbin/seal-system -f -r ${ROOT_DEV}
-                    /etc/init.d/trousers start
+                    do_cmd /etc/init.d/trousers stop >&2
+                    do_cmd chroot ${DOM0_MOUNT} \
+                        /usr/sbin/seal-system -f -r ${ROOT_DEV} >&2
+                    do_cmd /etc/init.d/trousers start >&2
                 fi
 
                 do_umount_all ${DOM0_MOUNT}

--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -30,7 +30,11 @@ create_lv() {
     fi
 
     lvcreate ${dfl_opts} --name ${name} ${opts} ${vg}
+    ret=$?
+
     udevadm settle
+
+    return $ret
 }
 
 mk_xc_lvm()


### PR DESCRIPTION
The compat codepaths were missing some error checking which this PR adds.  

`mount_upgrade_compat` wasn't exiting on failure, so execution continued.  Return an error for that case.

mount_upgrade_compat can fail if it wasn't written into a logical volume.  We need create_lv to return an error when it cannot create an LV.

While touching the seal_system, prefix the seal commands with `do_cmd` so they are logged.

NOTE: Regardless of this PR, we don't abort the installer on forward sealing failure.  This means we'll reboot and fail the measured launch.  At the time seal_system is called, all the files have been updated, so there isn't a way to fail gracefully.

"install-main: Return failure from create_lv " is a cherry pick from the master PR.
"install-main: Add do_cmd to seal_system" is a modified version of the master PR to include the compat code paths.

Master PR https://github.com/OpenXT/installer/pull/104