### PR TITLE
Error checking additions

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -450,9 +450,10 @@ seal_system() {
                 # Update config.pcrs in case it has changed
                 write_config_pcrs "${DOM0_MOUNT}"
 
-                /etc/init.d/trousers stop
-                chroot ${DOM0_MOUNT} /usr/sbin/seal-system -f -r ${ROOT_DEV}
-                /etc/init.d/trousers start
+                do_cmd /etc/init.d/trousers stop >&2
+                do_cmd chroot ${DOM0_MOUNT} \
+                    /usr/sbin/seal-system -f -r ${ROOT_DEV} >&2
+                do_cmd /etc/init.d/trousers start >&2
 
                 do_umount_all ${DOM0_MOUNT}
 

--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -30,7 +30,11 @@ create_lv() {
     fi
 
     lvcreate ${dfl_opts} --name ${name} ${opts} ${vg}
+    ret=$?
+
     udevadm settle
+
+    return $ret
 }
 
 mk_xc_lvm()


### PR DESCRIPTION
There are non-compat error checking additions from https://github.com/OpenXT/installer/pull/103

We need create_lv to return an error when it cannot create an LV.

While touching the seal_system, prefix the seal commands with do_cmd so they are logged.