### PR TITLE
OXT-1351: seal-system: Run write_config_pcrs from chroot

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -448,7 +448,8 @@ seal_system() {
                 echo "seal_system: /config is mounted, forward sealing key" >&2
 
                 # Update config.pcrs in case it has changed
-                write_config_pcrs "${DOM0_MOUNT}"
+                do_cmd chroot ${DOM0_MOUNT} \
+                    sh -c '. /usr/lib/openxt/ml-functions ; write_config_pcrs' >&2
 
                 do_cmd /etc/init.d/trousers stop >&2
                 do_cmd chroot ${DOM0_MOUNT} \


### PR DESCRIPTION
We need to chroot into the new root filesystem so that we write the new
pcr configuration and not the existing one.  Without this, we won't pick
up a new PCR configuration during an upgrade.

OXT-1351

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>