### PR TITLE
S9: OXT-1351: seal-system: Run write_config_pcrs from chroot

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -476,11 +476,11 @@ seal_system() {
             if is_mounted ${DOM0_MOUNT}/config ; then
                 echo "seal_system: /config is mounted, forward sealing key" >&2
 
-                # Update config.pcrs in case it has changed
-                write_config_pcrs "${DOM0_MOUNT}"
-
                 if [ "$(uname -m)" = "i686" ]; then
                     mount_upgrade_compat || return 1
+                    # Update config.pcrs in case it has changed
+                    do_cmd chroot ${UPGRADE_MOUNT} \
+                        sh -c '. /usr/lib/openxt/ml-functions ; write_config_pcrs' >&2
                     do_cmd /etc/init.d/trousers stop >&2
                     do_cmd chroot ${UPGRADE_MOUNT} \
                         /usr/sbin/seal-system -f -r ${ROOT_DEV} >&2
@@ -488,6 +488,9 @@ seal_system() {
                     umount_upgrade_compat
                     do_cmd lvremove -f /dev/xenclient/upgradecompat >&2
                 else
+                    # Update config.pcrs in case it has changed
+                    do_cmd chroot ${DOM0_MOUNT} \
+                        sh -c '. /usr/lib/openxt/ml-functions ; write_config_pcrs' >&2
                     do_cmd /etc/init.d/trousers stop >&2
                     do_cmd chroot ${DOM0_MOUNT} \
                         /usr/sbin/seal-system -f -r ${ROOT_DEV} >&2


### PR DESCRIPTION
This is the stable-9 version of https://github.com/OpenXT/installer/pull/106

We need to chroot into the new root filesystem so that we write the new
pcr configuration and not the existing one.  Without this, we won't pick
up a new PCR configuration during an upgrade.

OXT-1351

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>
(cherry picked from commit f55a626f4498b8458dd98e69061d1d5528e1a902)
[stable-9: Run out of compat-upgrade if necessary]