### PR TITLE
[stable-9] Add boot VGA device warning

### DIFF
--- a/part1/stages/Check-GPU
+++ b/part1/stages/Check-GPU
@@ -98,7 +98,7 @@ else
                    --yesno "$msg\n
   \ZbYou should check your BIOS settings.\ZB\n
 \n
-The UIVM only displays via the onbaord VGA device,\n
+The UIVM only displays via the onboard VGA device,\n
 either change boot VGA device in the BIOS or change primary display after installation completes.\n
 \n
 To change BIOS settings:\n\n

--- a/part1/stages/Check-GPU
+++ b/part1/stages/Check-GPU
@@ -68,18 +68,13 @@ contains() {
 
 check_vga()
 {
-    OLD_IFS=$IFS
-    IFS="
-"
     local onboard_pci="$(lspci -s 00: -d ::0300 | awk '{print $1}')"
-    for boot_vga in $(find /sys/ | grep boot_vga); do
+    for boot_vga in $(find /sys/ -name boot_vga); do
         if contains "$boot_vga" "$onboard_pci"; then
-            [ "$(cat $boot_vga)" -eq "1" ] || ret=1
+            [ "$(cat $boot_vga)" -eq "1" ] || return 1
             break
         fi
     done
-    IFS=${OLD_IFS}
-    return ${ret}
 }
 
 

--- a/part1/stages/Check-GPU
+++ b/part1/stages/Check-GPU
@@ -56,49 +56,14 @@ if [ ${GPU_OK} -ne 0 ] ; then
     echo "Ignoring unrecognised graphics device.">&2
 fi
 
-get_vga_pci_info()
-{
-    lspci -m | grep "VGA"
-}
-
-get_pci_id()
-{
-    echo $1 | awk '{print $1}'
-}
-
-get_pci_bus()
-{
-    echo $1 | cut -d: -f 1
-}
-
-get_onboard_pci_id()
-{
-    OLD_IFS=$IFS
-    IFS="
-"
-    for vga_dev in $(get_vga_pci_info); do
-        vga_id="$(get_pci_id $vga_dev)"
-        if [ "$(get_pci_bus $vga_id)" -eq "00" ]; then
-            echo "$vga_id"
-            break
-        fi
-    done
-    IFS=${OLD_IFS}
-}
-
 # Sourced from https://stackoverflow.com/a/8811800
 # BusyBox capable substring search
 # Try to remove the search substring from the search target string
 # If the stripped string is the same as the original target, substing was not found
 contains() {
-    string="$1"
-    substring="$2"
-    if test "${string#*$substring}" != "$string"
-    then
-        return 0    # $substring is in $string
-    else
-        return 1    # $substring is not in $string
-    fi
+    local string="$1"
+    local substring="$2"
+    [ "${string#*$substring}" != "$string" ]
 }
 
 check_vga()
@@ -106,10 +71,11 @@ check_vga()
     OLD_IFS=$IFS
     IFS="
 "
-    oboard_pci="$(get_onboard_pci_id)"
+    local onboard_pci="$(lspci -s 00: -d ::0300 | awk '{print $1}')"
     for boot_vga in $(find /sys/ | grep boot_vga); do
-        if contains "$boot_vga" "$oboard_pci"; then
+        if contains "$boot_vga" "$onboard_pci"; then
             [ "$(cat $boot_vga)" -eq "1" ] || ret=1
+            break
         fi
     done
     IFS=${OLD_IFS}
@@ -148,8 +114,6 @@ To change BIOS settings:\n\n
     OPT=$?
     [ "${OPT}" != 255 ] || exit ${Previous}
     [ "${OPT}" == 0 ]   || exit ${Abort}
-
-    echo "Onboard VGA device is not boot VGA device but continuing to install.">&2
 
     fi
 fi

--- a/part1/stages/Check-GPU
+++ b/part1/stages/Check-GPU
@@ -56,4 +56,102 @@ if [ ${GPU_OK} -ne 0 ] ; then
     echo "Ignoring unrecognised graphics device.">&2
 fi
 
+get_vga_pci_info()
+{
+    lspci -m | grep "VGA"
+}
+
+get_pci_id()
+{
+    echo $1 | awk '{print $1}'
+}
+
+get_pci_bus()
+{
+    echo $1 | cut -d: -f 1
+}
+
+get_onboard_pci_id()
+{
+    OLD_IFS=$IFS
+    IFS="
+"
+    for vga_dev in $(get_vga_pci_info); do
+        vga_id="$(get_pci_id $vga_dev)"
+        if [ "$(get_pci_bus $vga_id)" -eq "00" ]; then
+            echo "$vga_id"
+            break
+        fi
+    done
+    IFS=${OLD_IFS}
+}
+
+# Sourced from https://stackoverflow.com/a/8811800
+# BusyBox capable substring search
+# Try to remove the search substring from the search target string
+# If the stripped string is the same as the original target, substing was not found
+contains() {
+    string="$1"
+    substring="$2"
+    if test "${string#*$substring}" != "$string"
+    then
+        return 0    # $substring is in $string
+    else
+        return 1    # $substring is not in $string
+    fi
+}
+
+check_vga()
+{
+    OLD_IFS=$IFS
+    IFS="
+"
+    oboard_pci="$(get_onboard_pci_id)"
+    for boot_vga in $(find /sys/ | grep boot_vga); do
+        if contains "$boot_vga" "$oboard_pci"; then
+            [ "$(cat $boot_vga)" -eq "1" ] || ret=1
+        fi
+    done
+    IFS=${OLD_IFS}
+    return ${ret}
+}
+
+
+warning=0
+if check_vga; then
+    msg="Onboard VGA device is boot VGA device"
+else
+    msg="Onboard VGA device is NOT boot VGA device"
+    warning=1
+fi
+
+echo -e ${msg} >&2
+
+if ! interactive ; then
+    [ "${warning}" -ne "1" ] || echo -e "\nWARNING: $msg Check the BIOS settings.\n">&2
+else
+    if [ "${warning}" -eq "1" ] ; then
+        DIALOGRC="${DIALOG_WARN_RC}" \
+            dialog --colors --yes-label "Continue" \
+                            --no-label  "Abort" \
+                   --yesno "$msg\n
+  \ZbYou should check your BIOS settings.\ZB\n
+\n
+The UIVM only displays via the onbaord VGA device,\n
+either change boot VGA device in the BIOS or change primary display after installation completes.\n
+\n
+To change BIOS settings:\n\n
+ 1. Reboot and enter the BIOS configuration.\n
+ 2. Set boot VGA device to the onboard VGA device.\n
+ 3. \ZbPower OFF the machine completely.\ZB\n
+\n" 0 0
+    OPT=$?
+    [ "${OPT}" != 255 ] || exit ${Previous}
+    [ "${OPT}" == 0 ]   || exit ${Abort}
+
+    echo "Onboard VGA device is not boot VGA device but continuing to install.">&2
+
+    fi
+fi
+
 exit ${Continue}


### PR DESCRIPTION
Add a check to the host capabilities section that tests whether the
onboard VGA device is the boot VGA device. If not the user is served with
a warning. User can continue installation if desired, they are instructed
to change primary display after the install succeeds in such an event.

Related to OXT-1600

Signed-off-by: Tyler McGavran <mcgavrant@ainfosec.com>