### PR TITLE
OXT-1654: Handle NVMe symlinks in /dev.

### DIFF
--- a/common/stages/Functions/library
+++ b/common/stages/Functions/library
@@ -397,10 +397,26 @@ reread_partition_table()
 }
 
 #-----------------------------------------------------------
+# Usage: sanitize_devnode /dev/device
+# Should /dev/device be a symlink alias, follow the link and print the block
+# device path on stdout.
+sanitize_devnode() {
+    local dev="$1"
+
+    if [ -h "${dev}" ]; then
+        # NVMe may have entries in /dev that are symblink aliases to their
+        # block device (e.g, /dev/512GB_68PS115OT8JQ-part1 -> nvme0n1p1)
+        readlink -f "${dev}"
+    else
+        echo "${dev}"
+    fi
+}
+
+#-----------------------------------------------------------
 # Usage: get_devnode_disk /dev/(sd[a-z]\+[0-9]\+|/dev/nvme[0-9]\+n[0-9]\+p[0-9]\+)
 # Prints the disk component of the argument devnode on stdout.
 get_devnode_disk() {
-    local devnode="$1"
+    local devnode=$(sanitize_devnode "$1")
     local disk
 
     case "${devnode}" in
@@ -414,7 +430,7 @@ get_devnode_disk() {
 # Usage: get_devnode_partition /dev/(sd[a-z]\+[0-9]\+|/dev/nvme[0-9]\+n[0-9]\+p[0-9]\+)
 # Prints the partition component of the argument devnode on stdout.
 get_devnode_partition() {
-    local devnode="$1"
+    local devnode=$(sanitize_devnode "$1")
     local part
 
     case "${devnode}" in

--- a/part2/stages/Remove-partitions
+++ b/part2/stages/Remove-partitions
@@ -24,24 +24,13 @@
 
 # Remove every VG assigned to that disk.
 vgs=$(vgs --noheading -o vg_name)
-if [ -L ${TARGET_DISK} ]; then
-    dev="/dev/$(readlink ${TARGET_DISK})"
-else
-    dev="${TARGET_DISK}"
-fi
 for vg in ${vgs}; do
     # List all PV backing current VG.
     pvs="$(vgs --noheading -o pv_name ${vg})"
     pvs_on_target=""
     pvs_others=""
     for p in ${pvs}; do
-        if [ -L "${p}" ]; then
-            # NVMe will sometimes appear as symlinks to the actual device in
-            # the devfs (e.g: /dev/512GB_ -> nvme0n1p1).
-            dev="/dev/$(readlink ${p})"
-        else
-            dev="${p##/dev}"
-        fi
+        dev=$(sanitize_devnode "${p}")
         if [ "${dev##${TARGET_DISK}}" != "${dev}" ]; then
             pvs_on_target="${pvs_of_vg} ${dev}"
         else


### PR DESCRIPTION
udev may create a symlink alias to the block device in /dev for some NVMe drives. `get_devnode_{disk,partition}` assumes (per comment) they are passed the block device
path, but some utility tools (e.g, lvm-utils) can return the symlink alias instead that end up being passed as argument.
Add a sanitizing function to avoid that.

part2 already has snippets doing just that when trying to remove any existing LVM setup cleaning. So use the new function instead.