### PR TITLE
part2: renaming initramfs.gz to initrd

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -630,7 +630,7 @@ copy_to_esp()
           ${DOM0_MOUNT}/boot/shimx64.efi \
           ${DOM0_MOUNT}/boot/tboot \
           ${DOM0_MOUNT}/boot/bzImage \
-          ${DOM0_MOUNT}/boot/initramfs.gz \
+          ${DOM0_MOUNT}/boot/initrd \
           ${DOM0_MOUNT}/boot/*.bin \
           ${DOM0_MOUNT}/boot/*.BIN \
           ${DOM0_MOUNT}/etc/xen/xenrefpolicy/policy/policy.24 \


### PR DESCRIPTION
OpenEmbedded classes and recipes follow the convention that an image's
init image is called initrd when built into the image. In order to
better use OpenEmbedded's existing tooling it is helpful to follow then
naming convention of the init image.

This is tied to OpenXT/xenclient-oe#1221

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>