### PR TITLE
OXT-1701: part2: Deactivate VGs before LV manipulation.

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -41,6 +41,8 @@ mk_xc_lvm()
 {
     local PARTITION_DEV="$1"
 
+    do_cmd vgchange -a n || return 1
+
     do_cmd pvcreate -ff -y "${PARTITION_DEV}" || return 1
     do_cmd vgcreate xenclient "${PARTITION_DEV}" || return 1
     do_cmd create_lv xenclient boot --size 12M || return 1
@@ -54,8 +56,7 @@ mk_xc_lvm()
 
     do_cmd lvresize -f /dev/xenclient/storage -L-1G || return 1
 
-    do_cmd vgscan || return 1
-    do_cmd vgchange -a y xenclient || return 1
+    do_cmd vgchange -a y || return 1
 }
 
 apply_xc_packages()

--- a/part2/stages/Remove-partitions
+++ b/part2/stages/Remove-partitions
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/ash -e
 #
 # Copyright (c) 2017 Assured Information Security, Inc.
 # 
@@ -21,6 +21,9 @@
 
 . ${DISK_CONF}
 # ^^^ defines ${TARGET_DISK}
+
+# Deactivate LVs in all VGs.
+do_cmd vgchange -a n >&2
 
 # Remove every VG assigned to that disk.
 vgs=$(vgs --noheading -o vg_name)
@@ -70,5 +73,8 @@ done
 # Remove GPT partition table
 do_cmd sgdisk -Z /dev/${TARGET_DISK} >&2
 reread_partition_table "/dev/${TARGET_DISK}"
+
+# Re-activate LVs in al VGs,
+do_cmd vgchange -a y >&2
 
 exit ${Continue}


### PR DESCRIPTION
Doing so removes the handle from the device-mapper on the block device.
lvm-utils will fail to use the blockdev otherwise, e.g:
```
  Can't open /dev/nvme0n1p3 exclusively.  Mounted filesystem?
  Can't open /dev/nvme0n1p3 exclusively.  Mounted filesystem?
```