### PR TITLE
[shell] Replace ash with bash

### DIFF
--- a/answers/doc/answerfiles.txt
+++ b/answers/doc/answerfiles.txt
@@ -354,7 +354,7 @@ If this tag is present, skip the "are you ready to install?"
 interactive screen.
 
 ######################################################################
-<preinstall>#!/bin/ash
+<preinstall>#!/bin/bash
 touch /tmp/i.was.here
 </preinstall>
 
@@ -365,7 +365,7 @@ Note that including answertags in the preinstall script may confuse
 the answerfile parser: caution advised.
 
 ######################################################################
-<postinstall>#!/bin/ash
+<postinstall>#!/bin/bash
 touch /tmp/no.i.wasnt
 </postinstall>
 

--- a/answers/network.ans
+++ b/answers/network.ans
@@ -1,5 +1,5 @@
 <interactive>false</interactive>
-<preinstall>#!/bin/ash
+<preinstall>#!/bin/bash
 touch /tmp/preinstall.touch
 </preinstall>
 <eula accept="yes"></eula>
@@ -14,7 +14,7 @@ touch /tmp/preinstall.touch
 <recovery-password>RecoveryPassword</recovery-password>
 <enable-ssh>false</enable-ssh>
 <license-key>you-can-call-me-al</license-key>
-<postinstall>#!/bin/ash
+<postinstall>#!/bin/bash
 touch /tmp/postinstall.touch
 </postinstall>
 <allow-dev-repo-cert>true</allow-dev-repo-cert>

--- a/common/run-graph
+++ b/common/run-graph
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Graph-driven script controller
 #

--- a/common/stages/Configure-DHCP
+++ b/common/stages/Configure-DHCP
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/common/stages/Configure-static-IP
+++ b/common/stages/Configure-static-IP
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/common/stages/DHCP-or-static
+++ b/common/stages/DHCP-or-static
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/common/stages/Ensure-network-up
+++ b/common/stages/Ensure-network-up
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/common/stages/Functions/answerfile
+++ b/common/stages/Functions/answerfile
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/common/stages/Functions/fetch
+++ b/common/stages/Functions/fetch
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/common/stages/Functions/library
+++ b/common/stages/Functions/library
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/common/stages/Functions/repository-common
+++ b/common/stages/Functions/repository-common
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/common/stages/Select-NIC
+++ b/common/stages/Select-NIC
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Activate-drivers
+++ b/part1/stages/Activate-drivers
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Apply-extra-disks
+++ b/part1/stages/Apply-extra-disks
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Bad-media
+++ b/part1/stages/Bad-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Check-GPU
+++ b/part1/stages/Check-GPU
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part1/stages/Check-host-capabilities
+++ b/part1/stages/Check-host-capabilities
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part1/stages/Check-initrd-data
+++ b/part1/stages/Check-initrd-data
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Choose-extra-source
+++ b/part1/stages/Choose-extra-source
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Choose-install-type
+++ b/part1/stages/Choose-install-type
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part1/stages/Commit-extra
+++ b/part1/stages/Commit-extra
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Commit-extra-disks
+++ b/part1/stages/Commit-extra-disks
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Commit-main
+++ b/part1/stages/Commit-main
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part1/stages/Configure-hard-disk-repo
+++ b/part1/stages/Configure-hard-disk-repo
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Configure-keyboard
+++ b/part1/stages/Configure-keyboard
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Configure-language
+++ b/part1/stages/Configure-language
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part1/stages/Configure-network-repo
+++ b/part1/stages/Configure-network-repo
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Configure-repo-cert
+++ b/part1/stages/Configure-repo-cert
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Copy-install-files
+++ b/part1/stages/Copy-install-files
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Detect-repo
+++ b/part1/stages/Detect-repo
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part1/stages/Download-install-files
+++ b/part1/stages/Download-install-files
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/EULA
+++ b/part1/stages/EULA
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/EULA-declined
+++ b/part1/stages/EULA-declined
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Eject-cd
+++ b/part1/stages/Eject-cd
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Eject-disk
+++ b/part1/stages/Eject-disk
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Extra-from-optical-media
+++ b/part1/stages/Extra-from-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part1/stages/Extract-control-package
+++ b/part1/stages/Extract-control-package
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Fail
+++ b/part1/stages/Fail
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Functions/branding
+++ b/part1/stages/Functions/branding
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2014 Citrix Systems, Inc.
 # 

--- a/part1/stages/Functions/defaults
+++ b/part1/stages/Functions/defaults
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Functions/file-paths
+++ b/part1/stages/Functions/file-paths
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part1/stages/Functions/install-main
+++ b/part1/stages/Functions/install-main
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Functions/optical-media
+++ b/part1/stages/Functions/optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Functions/repository
+++ b/part1/stages/Functions/repository
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part1/stages/Functions/subgraph
+++ b/part1/stages/Functions/subgraph
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Functions/supp-packs
+++ b/part1/stages/Functions/supp-packs
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part1/stages/Functions/version
+++ b/part1/stages/Functions/version
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2014 Citrix Systems, Inc.
 # 

--- a/part1/stages/Get-answerfile
+++ b/part1/stages/Get-answerfile
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright 2009 (c) Citrix Systems
 #

--- a/part1/stages/Initialise-state
+++ b/part1/stages/Initialise-state
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Install-extra
+++ b/part1/stages/Install-extra
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Install-from-optical-media
+++ b/part1/stages/Install-from-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part1/stages/Install-main
+++ b/part1/stages/Install-main
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Iscsi-configure-repo
+++ b/part1/stages/Iscsi-configure-repo
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Iscsi-confirm-repo
+++ b/part1/stages/Iscsi-confirm-repo
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Iscsi-copy-install-files
+++ b/part1/stages/Iscsi-copy-install-files
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Locate-optical-failed
+++ b/part1/stages/Locate-optical-failed
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Locate-optical-media
+++ b/part1/stages/Locate-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Mount-optical-media
+++ b/part1/stages/Mount-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Mount-usb-media
+++ b/part1/stages/Mount-usb-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part1/stages/Optional-extra-disks
+++ b/part1/stages/Optional-extra-disks
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part1/stages/Post-all-extras-hook
+++ b/part1/stages/Post-all-extras-hook
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Post-extra-hook
+++ b/part1/stages/Post-extra-hook
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Post-install-extras-hook
+++ b/part1/stages/Post-install-extras-hook
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Pre-install-hook
+++ b/part1/stages/Pre-install-hook
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Preserve-install-data
+++ b/part1/stages/Preserve-install-data
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Previous-barrier
+++ b/part1/stages/Previous-barrier
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Reboot
+++ b/part1/stages/Reboot
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Request-disk
+++ b/part1/stages/Request-disk
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Request-optical-media
+++ b/part1/stages/Request-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Shutdown
+++ b/part1/stages/Shutdown
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Status-report
+++ b/part1/stages/Status-report
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part1/stages/Status-server
+++ b/part1/stages/Status-server
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 
@@ -70,7 +70,7 @@ SERVE_SCRIPT="/tmp/serve-script/sh"
 mkdir -p "$(dirname ${SERVE_SCRIPT})"
 
 cat >"${SERVE_SCRIPT}" <<EOF
-#!/bin/ash
+#!/bin/bash
 
 REPORT="${REPORT}"
 REDIRECT_FILE="${REDIRECT_FILE}"

--- a/part1/stages/Status-welcome
+++ b/part1/stages/Status-welcome
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Succeed
+++ b/part1/stages/Succeed
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Unexpected-failure
+++ b/part1/stages/Unexpected-failure
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Verify-optical-media
+++ b/part1/stages/Verify-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part1/stages/Welcome
+++ b/part1/stages/Welcome
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2014 Citrix Systems, Inc.
 # 

--- a/part1/stages/X-check-initrd-data
+++ b/part1/stages/X-check-initrd-data
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/X-ensure-network-is-up
+++ b/part1/stages/X-ensure-network-is-up
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/X-locate-optical-media
+++ b/part1/stages/X-locate-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/X-mount-optical-media
+++ b/part1/stages/X-mount-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/X-record-optical-pack-data
+++ b/part1/stages/X-record-optical-pack-data
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/X-verify-optical-media
+++ b/part1/stages/X-verify-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part1/stages/Y-locate-optical-media
+++ b/part1/stages/Y-locate-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part1/stages/Y-verify-optical-media
+++ b/part1/stages/Y-verify-optical-media
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part1/stages/functions
+++ b/part1/stages/functions
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/run
+++ b/part2/run
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Commit-extra
+++ b/part2/stages/Commit-extra
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part2/stages/Commit-main
+++ b/part2/stages/Commit-main
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/Commit-preserved-data
+++ b/part2/stages/Commit-preserved-data
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2014 Citrix Systems, Inc.
 # 

--- a/part2/stages/Configure-GPT
+++ b/part2/stages/Configure-GPT
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Configure-VHDs
+++ b/part2/stages/Configure-VHDs
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Configure-VMs
+++ b/part2/stages/Configure-VMs
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Configure-partitions
+++ b/part2/stages/Configure-partitions
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/Enable-SSH
+++ b/part2/stages/Enable-SSH
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Examine-repository
+++ b/part2/stages/Examine-repository
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Fail
+++ b/part2/stages/Fail
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Find-existing-install
+++ b/part2/stages/Find-existing-install
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2014 Citrix Systems, Inc.
 # 

--- a/part2/stages/Functions/branding
+++ b/part2/stages/Functions/branding
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2014 Citrix Systems, Inc.
 # 

--- a/part2/stages/Functions/defaults
+++ b/part2/stages/Functions/defaults
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part2/stages/Functions/file-paths
+++ b/part2/stages/Functions/file-paths
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2014 Citrix Systems, Inc.
 # 

--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2014 Citrix Systems, Inc.
 # 

--- a/part2/stages/Functions/install-vhds
+++ b/part2/stages/Functions/install-vhds
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Functions/install-vms
+++ b/part2/stages/Functions/install-vms
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Initialise-state
+++ b/part2/stages/Initialise-state
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Install-extra
+++ b/part2/stages/Install-extra
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2012 Citrix Systems, Inc.
 # 

--- a/part2/stages/Install-fresh
+++ b/part2/stages/Install-fresh
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/Install-hook
+++ b/part2/stages/Install-hook
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Install-upgrade
+++ b/part2/stages/Install-upgrade
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/Make-BBP-partition
+++ b/part2/stages/Make-BBP-partition
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/Make-ESP-partition
+++ b/part2/stages/Make-ESP-partition
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/Make-XC-partition
+++ b/part2/stages/Make-XC-partition
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/Post-commit-hook
+++ b/part2/stages/Post-commit-hook
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Post-install-hook
+++ b/part2/stages/Post-install-hook
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Pre-commit-hook
+++ b/part2/stages/Pre-commit-hook
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Preserve-install-data
+++ b/part2/stages/Preserve-install-data
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Ready-to-install
+++ b/part2/stages/Ready-to-install
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Ready-to-upgrade
+++ b/part2/stages/Ready-to-upgrade
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Remove-partitions
+++ b/part2/stages/Remove-partitions
@@ -1,4 +1,4 @@
-#!/bin/ash -e
+#!/bin/bash -e
 #
 # Copyright (c) 2017 Assured Information Security, Inc.
 # 

--- a/part2/stages/Seal-upgrade
+++ b/part2/stages/Seal-upgrade
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # Copyright (c) 2016 Daniel P. Smith, Apertus Solutions, LLC

--- a/part2/stages/Select-hard-disk
+++ b/part2/stages/Select-hard-disk
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Set-password
+++ b/part2/stages/Set-password
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # Copyright (C) 2017 Jason Andryuk

--- a/part2/stages/Succeed
+++ b/part2/stages/Succeed
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/TPM-BadSrk
+++ b/part2/stages/TPM-BadSrk
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/TPM-Begin
+++ b/part2/stages/TPM-Begin
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/TPM-Check
+++ b/part2/stages/TPM-Check
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/TPM-Disabled
+++ b/part2/stages/TPM-Disabled
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/TPM-Error
+++ b/part2/stages/TPM-Error
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/TPM-Inactive
+++ b/part2/stages/TPM-Inactive
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/TPM-Owned
+++ b/part2/stages/TPM-Owned
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/TPM-RUSure
+++ b/part2/stages/TPM-RUSure
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/TPM-Timeout
+++ b/part2/stages/TPM-Timeout
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # Copyright (c) 2017 Jason Andryuk

--- a/part2/stages/TXT-Fail
+++ b/part2/stages/TXT-Fail
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/Unexpected-failure
+++ b/part2/stages/Unexpected-failure
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Unlock-config
+++ b/part2/stages/Unlock-config
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (C) 2017 Jason Andryuk
 #

--- a/part2/stages/Upgrade-hook
+++ b/part2/stages/Upgrade-hook
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2011 Citrix Systems, Inc.
 # 

--- a/part2/stages/Warn-disk-erasure
+++ b/part2/stages/Warn-disk-erasure
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/stages/functions
+++ b/part2/stages/functions
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2013 Citrix Systems, Inc.
 # 

--- a/part2/upgrade
+++ b/part2/upgrade
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/bash
 #
 # Copyright (c) 2014 Citrix Systems, Inc.
 # 


### PR DESCRIPTION
Looking to get feedback on this. AFAIK there are no good enough reasons for the installer to still be using ash, especially when we've had to make workarounds for things that work in bash but not in ash. Anybody opposed to switching? Tested a standard install with bash, no issues.