### PR TITLE
part1: Attend minor glitches in media detection and repository unpacking

### DIFF
--- a/part1/stages/Choose-install-type
+++ b/part1/stages/Choose-install-type
@@ -44,13 +44,13 @@ EOF
 #------------------------------------------------------------------------------
 auto_detect()
 {
-    if [ "${DETECTED_REPO_COUNT}" = 1 ] ; then
+    if [ "${DETECTED_REPO_COUNT}" -eq "1" ] ; then
         echo "Installing using ${DETECTED_REPO_SOURCE}" >&2
         save_conf_and_exit "$DETECTED_REPO_SOURCE"
     else
-        if [ "${DETECTED_REPO_COUNT}" > 1 ] ; then
+        if [ "${DETECTED_REPO_COUNT}" -gt "1" ] ; then
             echo "Multiple repo locations detected: falling back to interactive menu mode.">&2 
-        elif [ "${DETECTED_REPO_COUNT}" = 0 ] ; then
+        elif [ "${DETECTED_REPO_COUNT}" -eq "0" ] ; then
             echo "No repo location found: falling back to interactive menu mode.">&2 
         fi
 
@@ -126,11 +126,11 @@ fi
                                 7 40 0 2>${CAPTURE}
     local OPT="$?"
 
-    if [ "${OPT}" != 0 ] ; then
+    if [ "${OPT}" -ne "0" ] ; then
         rm -f ${CAPTURE}
-        [ "${OPT}" == 1 ]   && exit ${Abort}
-        [ "${OPT}" == 123 ] && exit ${Previous}
-        [ "${OPT}" == 124 ] && exit ${Previous}
+        [ "${OPT}" -eq "1" ]   && exit ${Abort}
+        [ "${OPT}" -eq "123" ] && exit ${Previous}
+        [ "${OPT}" -eq "124" ] && exit ${Previous}
         exit ${Abort}
     fi
 

--- a/part1/stages/Functions/install-main
+++ b/part1/stages/Functions/install-main
@@ -113,14 +113,19 @@ extract_control_package()
 
     echo -e >&2 "Extracting control package" \
                 "\nType: ${PACKAGE_TYPE}" \
-                "\nFrom: ${PACKAGE_FILE}"
+                "\nFrom: ${PACKAGE_FILE}" \
+                "\nTo:   ${CONTROL_DIR}"
 
     case "${PACKAGE_TYPE}" in
         tarbz2)
-            bunzip2 -q -c "${PACKAGE_FILE}" | tar -x -f - -C "${CONTROL_DIR}"
+            if ! tar xjf "${PACKAGE_FILE}" -C "${CONTROL_DIR}"; then
+                echo "ERROR: Failure to extract ${PACKAGE_FILE}" >&2
+                return 1
+            fi
 
             if [ ! -x "${CONTROL_DIR}/${SUBGRAPH_SCRIPT}" ] ; then
-                echo "ERROR: Failure to extract ${PACKAGE_FILE}">&2
+                echo "ERROR: Invalid ${PACKAGE_FILE}, cannot find " \
+                    "${CONTROL_DIR}/${SUBGRAPH_SCRIPT}">&2
                 return 1
             fi
             ;;

--- a/part1/stages/Functions/optical-media
+++ b/part1/stages/Functions/optical-media
@@ -20,7 +20,9 @@
 #------------------------------------------------------------
 list_cdrom_devices()
 {
-    sed -ne 's/^drive name:\s*//p' </proc/sys/dev/cdrom/info 2>/dev/null
+    if [ -e "/proc/sys/dev/cdrom/info" ]; then
+        sed -ne 's/^drive name:\s*//p' </proc/sys/dev/cdrom/info 2>/dev/null
+    fi
 }
 
 #------------------------------------------------------------


### PR DESCRIPTION
- There is a spurious error when trying to detect if the platform has a cdrom drive, silence it.
- Fix bash `test` operators misuses in `install-main` when unpacking the part2 (control) tarball, amend the other operators while at it
- Add some informations to diagnose issues that may arise with the part2 (control) tarball.