### PR TITLE
part2: Delay forward seal until VMs are not running

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -452,10 +452,9 @@ seal_system() {
                 do_cmd chroot ${DOM0_MOUNT} \
                     sh -c '. /usr/lib/openxt/ml-functions ; write_config_pcrs' >&2
 
-                do_cmd /etc/init.d/trousers stop >&2
-                do_cmd chroot ${DOM0_MOUNT} \
-                    /usr/sbin/seal-system -f -r ${ROOT_DEV} >&2
-                do_cmd /etc/init.d/trousers start >&2
+                # touch marker and let delayed-seal initscript handle
+                # sealing during shutdown when VMs aren't running.
+                touch /tmp/upgrade-delayed-seal
 
                 do_umount_all ${DOM0_MOUNT}
 


### PR DESCRIPTION
Don't run seal-system directly. The TPM interactions could have their MMIO data snooped. Instead we touch a marker file and let the delayed-seal initscript detect and run the forward seal at shutdown time. This is done when the VMs are not running, so we shouldn't have anyone around to snoop on the transaction.

This PR is dependent on [xenclient-oe PR#1493](https://github.com/OpenXT/xenclient-oe/pull/1493).