### PR TITLE
Bump config partition size to 26M

### DIFF
--- a/part2/stages/Functions/install-main
+++ b/part2/stages/Functions/install-main
@@ -46,7 +46,7 @@ mk_xc_lvm()
     do_cmd pvcreate -ff -y "${PARTITION_DEV}" || return 1
     do_cmd vgcreate xenclient "${PARTITION_DEV}" || return 1
     do_cmd create_lv xenclient boot --size 12M || return 1
-    do_cmd create_lv xenclient config --size 12M || return 1
+    do_cmd create_lv xenclient config --size 26M || return 1
     do_cmd create_lv xenclient root --size ${DOM0_ROOT_LV_SIZE} || return 1
     do_cmd create_lv xenclient root.new --size ${DOM0_ROOT_LV_SIZE} || return 1
     do_cmd create_lv xenclient swap --size 256M || return 1


### PR DESCRIPTION
A luks2 volume requires >16M, so the current size of 12M causes an offset error. Originally with luks1 the header size was 2M and 10M usable space was allocated. With the bump to 16M header, we now allocate 26M.